### PR TITLE
fixed bug with plugins not folowing master branch

### DIFF
--- a/plugin/vim-outdated-plugins.vim
+++ b/plugin/vim-outdated-plugins.vim
@@ -13,7 +13,7 @@ function! s:CalculateUpdates(job_id, data, event) dict
   let l:command = ""
 
   for key in keys(g:plugs)
-    let l:command .= '(git -C ' . g:plugs[key].dir . ' rev-list HEAD..origin --count)'
+    let l:command .= '(git -C ' . g:plugs[key].dir . ' rev-list HEAD..origin/'. g:plugs[key].branch .' --count)'
     let l:numberOfcheckedPlugins += 1
 
     if l:numberOfcheckedPlugins != len(keys(g:plugs))


### PR DESCRIPTION
For plugins that are following a branch that is not master.  (i.e. if you had `Plug 'neoclide/coc.nvim', {'branch': 'release'}`), outdated-plugins would incorrectly mark that plugin as not updated if the release branch was not caught up with master.  This pull request fixes that by referencing the correct branch in the `git rev-list` command